### PR TITLE
Add docker-compose and dockerfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+version: '3'
+services:
+  db:
+    build: 
+      context: ./
+      dockerfile: postgres.dockerfile
+    restart: unless-stopped
+    container_name: db
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=foobar
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    networks:
+      - mynetwork
+
+  pgadmin:
+    image: "dpage/pgadmin4"
+    restart: unless-stopped
+    container_name: pgadmin
+    depends_on:
+      - db
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "foobar@cenfoo.fr"
+      PGADMIN_DEFAULT_PASSWORD: "postgres"
+      PGADMIN_LISTEN_PORT: 8001
+    ports:
+      - "5050:8001"
+    networks:
+      - mynetwork
+
+  web:
+    build:
+      context: ./
+      dockerfile: web.dockerfile
+ 
+    restart: unless-stopped
+    container_name: web
+    volumes:
+      - ./:/var/www/html
+    ports:
+      - "82:80"
+    depends_on:
+      - db
+    networks:
+      - mynetwork
+volumes:
+  postgres-data:
+networks:
+  mynetwork:
+    driver: bridge

--- a/postgres.dockerfile
+++ b/postgres.dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1
+FROM postgres
+
+RUN apt-get update && apt-get  install -y postgresql-16-postgis-3 
+
+EXPOSE 5432

--- a/web.dockerfile
+++ b/web.dockerfile
@@ -1,0 +1,19 @@
+FROM debian:bullseye-slim
+
+# Update and install APACHE2 and PYTHON 
+RUN apt-get update
+RUN apt-get install -y vim curl apache2 apache2-utils php-common libapache2-mod-php php-cli php-pgsql
+
+# Copy Kollect project's files
+WORKDIR /var/www/html
+RUN rm -r *
+RUN echo '<?php phpinfo( ); ?>' > phpinfo.php
+
+RUN echo "Copy www folder."
+COPY . .
+
+RUN chmod -R 775 /var/www/html/
+RUN chown -R www-data: /var/www/html/
+
+EXPOSE 80
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/web.dockerfile.dockerignore
+++ b/web.dockerfile.dockerignore
@@ -1,0 +1,5 @@
+*.dockerfile
+docker-compose.yml
+postgres-data
+
+.*


### PR DESCRIPTION
Bonjour,

Comme évoqué avec Romain, je partage mes fichiers "docker-compose" afin de containériser votre projet.
Dans mon programme 2024, je devrais mettre en place tel un outil pour l'étude des chiroptères. visiblement, la partie déploiement sera plus rapide que prévu. ^^

Le fichier docker-compose comporte les informations de connexion à la bdd et à Pgadmin et se découpe en 3 containers :

- web, il s'agit de l'application servit par un serveur Apache + PHP. Un volume est défini pour ne pas perdre de données au redémarrage du container. Accessible sous le port 82. 
- bdd, de type PGSQL avec PostGIS installé. Un volume est également présent afin de ne pas perdre la base de données en ca de redémarrage du container.
- PgAdmin, c'est plus sympa d'en avoir un sous la main. A la configuration d'une nouvelle connexion, il faut indiquer db comme host au lieu de localhost. Accessible sous le port 5050.

Une fois Docker installé sur votre machine, placer vous en ligne de commande dans le dossier du projet et lancez :
docker compose up
( [https://docs.docker.com/compose/gettingstarted/](url) )

Je suis disponible pour échanger.